### PR TITLE
Add Python3 in SB image

### DIFF
--- a/superbuild/Dockerfile
+++ b/superbuild/Dockerfile
@@ -26,7 +26,9 @@ RUN apt update && apt install -y \
       libxt-dev
 
 # Install F3D build dependency
-RUN apt update && apt install -y help2man
+RUN apt update && apt install -y \
+      help2man \
+      python3-dev
 
 # Install superbuild dependencies
 RUN apt update && apt install -y \


### PR DESCRIPTION
We will use system Python in the SB since it's only a build dependency.  
Let's install it in the Docker image in order to use it.