### PR TITLE
Enable Docker buildx

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -30,6 +30,9 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build and push
       uses: docker/build-push-action@v6
       with:
@@ -47,6 +50,9 @@ jobs:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Recover versions.json to parse
       working-directory: ${{github.workspace}}
@@ -102,6 +108,9 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Recover versions.json to parse
       working-directory: ${{github.workspace}}
       shell: bash
@@ -155,6 +164,9 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Build and push superbuild
       uses: docker/build-push-action@v6
       with:
@@ -173,6 +185,8 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push wheels
       uses: docker/build-push-action@v6


### PR DESCRIPTION
From https://github.com/docker/build-push-action?tab=readme-ov-file :

> [setup-buildx](https://github.com/docker/setup-buildx-action) action will create and boot a builder using by default the [docker-container driver](https://docs.docker.com/build/building/drivers/docker-container/). This is not required but recommended using it to be able to build multi-platform images, export cache, etc.