### PR TITLE
Add rendering grid axes dependency

### DIFF
--- a/android/Dockerfile
+++ b/android/Dockerfile
@@ -207,7 +207,8 @@ RUN cmake -S /vtk-src -B /vtk-build \
       -DANDROID_NDK=/ndk \
       -DCMAKE_BUILD_TYPE=Release \
       -DVTK_ANDROID_BUILD=ON \
-      -DVTK_ANDROID_USER_OPTIONS="-DVTK_MODULE_ENABLE_VTK_IOInfovis=NO;-DVTK_MODULE_ENABLE_VTK_RenderingLabel=NO;-DVTK_MODULE_ENABLE_VTK_TestingRendering=NO"
+      -DVTK_ANDROID_USER_OPTIONS="-DVTK_MODULE_ENABLE_VTK_IOInfovis=NO;-DVTK_MODULE_ENABLE_VTK_RenderingLabel=NO;-DVTK_MODULE_ENABLE_VTK_TestingRendering=NO;-DVTK_MODULE_ENABLE_VTK_RenderingGridAxes=YES"
+
 
 RUN cmake --build /vtk-build && rm -rf /vtk-src
 

--- a/webassembly/Dockerfile
+++ b/webassembly/Dockerfile
@@ -170,6 +170,7 @@ RUN cmake -S /vtk-src -B /vtk-build \
   -DVTK_MODULE_ENABLE_VTK_InteractionWidgets=YES \
   -DVTK_MODULE_ENABLE_VTK_RenderingAnnotation=YES \
   -DVTK_MODULE_ENABLE_VTK_RenderingCore=YES \
+  -DVTK_MODULE_ENABLE_VTK_RenderingGridAxes=YES \
   -DVTK_MODULE_ENABLE_VTK_RenderingOpenGL2=YES \
   -DVTK_MODULE_ENABLE_VTK_RenderingVolumeOpenGL2=YES \
   -DVTK_MODULE_ENABLE_VTK_TestingCore=YES \


### PR DESCRIPTION
This change is required in relation to https://github.com/f3d-app/f3d/pull/2100 

RenderingGridAxes must be added as a dependency before CI will pass for the PR.