### PR TITLE
Use GCC-13 for the SB image

### DIFF
--- a/superbuild/Dockerfile
+++ b/superbuild/Dockerfile
@@ -47,10 +47,16 @@ RUN apt update && apt install -y \
       git-lfs \
       jq
 
-# Install up-to-date needed packages
+# Install newer CMake
 RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
 RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ jammy main'
 RUN apt update && apt install -y cmake=3.31.6-0kitware1ubuntu22.04.1 cmake-data=3.31.6-0kitware1ubuntu22.04.1
+
+# Install GCC-13 (for C++20 support)
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt update && apt install -y gcc-13 g++-13
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100 \
+ && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
 
 # Install sccache
 RUN cargo install sccache --version 0.4.2 --locked


### PR DESCRIPTION
Required for C++20 compatibility

Docker image tested locally:
```
root@f01c4e23215b:/# g++ --version
g++ (Ubuntu 13.4.0-6ubuntu1~22~ppa2) 13.4.0
```